### PR TITLE
Updates SPF to hide the search box from the stock UI

### DIFF
--- a/SigmaProfessionFilter/TradeSkillFrame/Frames/TextSearch/SearchBox.lua
+++ b/SigmaProfessionFilter/TradeSkillFrame/Frames/TextSearch/SearchBox.lua
@@ -21,6 +21,7 @@ function SPF2.SearchBox.OnLoad()
     if (not (LeaPlusDB == nil) and LeaPlusDB["EnhanceProfessions"] == "On") then
         SPF2.SearchBox:SetPoint("TOPRIGHT", TradeSkillFrame, "TOPRIGHT", -50, -40);
 		SPF2.SearchBox:SetWidth(300);
+		TradeSkillListScrollFrame:HookScript("OnUpdate", SPF2.SearchBox.HideStockSearch);
     end
 end
 
@@ -73,6 +74,10 @@ function SPF2.SearchBox:FilterSpell(spellID)
 	else
 		return SPF2:FilterSpellWithSearchBox(spellID);
 	end
+end
+
+function SPF2.SearchBox:HideStockSearch()
+	TradeSearchInputBox:Hide()
 end
 
 SPF2.SearchBox.OnLoad();


### PR DESCRIPTION
When the box isn't hidden it appears under the checkbox option row when LTP is enabled. This may also happen with stock UI.

See: (https://github.com/Ketho/wow-ui-source-tbc/blob/2432d6876de943147b0a47bdfabaa282fd79a469/Interface_TBC/AddOns/Blizzard_TradeSkillUI/Blizzard_TradeSkillUI.lua#L102-L106).

